### PR TITLE
Redefine tag according to the selected framework

### DIFF
--- a/esphome/core/log.cpp
+++ b/esphome/core/log.cpp
@@ -52,8 +52,11 @@ int HOT esp_idf_log_vprintf_(const char *format, va_list args) {  // NOLINT
   auto *log = logger::global_logger;
   if (log == nullptr)
     return 0;
-
+#if defined(USE_ESP32_FRAMEWORK_ARDUINO)
+  log->log_vprintf_(ESPHOME_LOG_LEVEL, "esp-arduino", 0, format, args);
+#else
   log->log_vprintf_(ESPHOME_LOG_LEVEL, "esp-idf", 0, format, args);
+#endif
 #endif
   return 0;
 }


### PR DESCRIPTION
Redefine the output of the tag (esp-arduino or esp_idf) in the log, according to the selected framework.

# What does this implement/fix?

If there are different ESPs with different frameworks, there is confusion when viewing the log, it is better to specify a tag (esp-arduino or esp_idf), depending on the chosen framework.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [X] ESP32
- [X] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040

## Example entry for `config.yaml`:
<!--
  Supplying a configuration snippet, makes it easier for a maintainer to test
  your PR. Furthermore, for new integrations, it gives an impression of how
  the configuration would look like.
  Note: Remove this section if this PR does not have an example entry.
-->

```yaml
# Example config.yaml

```

## Checklist:
  - [X] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
